### PR TITLE
Make brainageR script executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -215,3 +215,4 @@ USE_OPENMP=ON \
 make && \
 make install
 
+RUN chmod +x /opt/brainageR/software/brainageR


### PR DESCRIPTION
The brainageR script would not run without adding the executable permission. This resolves that problem during the Docker image build